### PR TITLE
Fix dynamic diagram when mode changes

### DIFF
--- a/src/dynamicDiagram/diagram-index.ts
+++ b/src/dynamicDiagram/diagram-index.ts
@@ -181,6 +181,13 @@ function readyForLayoutElems(elements) {
   )
 }
 
+function recreateDiagram(currentElements) {
+  changeElementsMode()
+  cy.elements().remove()
+  cy.add(currentElements)
+  updateLayout()
+}
+
 function modeChanged() {
   const toggleMode = getInputElement('toggle-mode')
   const newTitle = toggleMode.checked ? 'Dark mode ON' : 'Light Mode ON'
@@ -188,8 +195,7 @@ function modeChanged() {
 
   // @ts-expect-error it works and we need it
   document.getElementById('main').style = `background-color: ${backgroundColor()}`
-  cy.elements().remove()
-  reloadDiagram(currentElements)
+  recreateDiagram([...currentElements])
 }
 
 function backgroundColor() {


### PR DESCRIPTION
Hoy lo que pasa es que con el arreglo que hicimos para detectar cambios, al cambiar el modo claro a oscuro o viceversa, nos quedamos sin nodos porque previamente se borraban todos los elementos de cytoscape:

![bug-dynamic-diagram-mode](https://github.com/user-attachments/assets/299c865e-7695-4715-b74f-ed8d457354bc)

Como se puede ver, si vos refrescás los nodos vuelven a aparecer pero perdés la configuración.

Esto ya lo pude corregir para el sitio web nuevo pero hay que arreglarlo acá.